### PR TITLE
Fixed an issue with IE and event being 'undefined' in the window.onbeforeunload function.

### DIFF
--- a/src/jquery.confirm.it.js
+++ b/src/jquery.confirm.it.js
@@ -3,7 +3,7 @@
  *
  * @version: 1.0.1
  * @requires: jQuery v1.6
- * @copyright: © 2011 John Pencola / Steve Perrie under the GNU GPL license (meaning you can use it freely!)
+ * @copyright: ï¿½ 2011 John Pencola / Steve Perrie under the GNU GPL license (meaning you can use it freely!)
  * @documentation: https://github.com/jpencola/jQuery-ConfirmIt/
  * @API:
  * 
@@ -128,6 +128,14 @@ var ConfirmIt = (function(){
 				//	binds the confirm leave handler on the window object
 				function bindFormConfirmHandler(element){
 					var confirmIfChanged = function(event){  
+						if (!event) {
+						        
+							// IE doesn't get 
+							// the event passed in
+							// so we have to use window.event
+							// see http://www.quirksmode.org/js/events_access.html
+							var event = window.event;
+						}
 						//	if the form has been not been altered
 						if (!element.data('data-confirmit-altered')){  
 							//	cancel the event and leave the page


### PR DESCRIPTION
See this page: http://www.quirksmode.org/js/events_access.html
and this SO answer: http://stackoverflow.com/questions/3774468/event-is-undefined-in-ie-works-in-firefox/3774493#3774493
